### PR TITLE
Update ACPI README links

### DIFF
--- a/docs/Battery/README by whatnameist.md
+++ b/docs/Battery/README by whatnameist.md
@@ -1,5 +1,5 @@
 # Battery: Modified RECB and WECB methods
-by whatnameis | [link to original README.md](https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/blob/master/Docs/README.md)
+by whatnameis | [link to original README.md](https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/blob/master/Docs/Battery/README.md)
 ## Problem
 I was studying the [_new_ battery patch guide](https://xstar-dev.github.io/hackintosh_advanced/Guide_For_Battery_Hotpatch.html) and was wondering if there was a simpler way of reading and writing `FieldUnitObjs` with size above 32 bits.\
 There are many databases which contain battery patches for various laptops, but they are not very consistent when breaking up `FieldUnitObjs` size above 32 bits. If the `OperationRegion` starts at `Zero`, then they use `RE1B` and `RECB` (or `WE1B` and `WECB`. I should inclusively call them `xE1B` and `xECB`.) methods. If it starts at something other than `Zero`, then they break up `256` bits into a set of 32 `FieldUnitObjs` and write every single one of them into `xRBA` methods. A lack of a unified guide, and also tiring to rewrite all the broken down `FieldUnitObjs`...\

--- a/docs/Battery/README by whatnameist.md
+++ b/docs/Battery/README by whatnameist.md
@@ -1,5 +1,5 @@
 # Battery: Modified RECB and WECB methods
-by whatnameis | [link to original README.md](https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/blob/master/OC/ACPI/README.md)
+by whatnameis | [link to original README.md](https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/blob/master/Docs/README.md)
 ## Problem
 I was studying the [_new_ battery patch guide](https://xstar-dev.github.io/hackintosh_advanced/Guide_For_Battery_Hotpatch.html) and was wondering if there was a simpler way of reading and writing `FieldUnitObjs` with size above 32 bits.\
 There are many databases which contain battery patches for various laptops, but they are not very consistent when breaking up `FieldUnitObjs` size above 32 bits. If the `OperationRegion` starts at `Zero`, then they use `RE1B` and `RECB` (or `WE1B` and `WECB`. I should inclusively call them `xE1B` and `xECB`.) methods. If it starts at something other than `Zero`, then they break up `256` bits into a set of 32 `FieldUnitObjs` and write every single one of them into `xRBA` methods. A lack of a unified guide, and also tiring to rewrite all the broken down `FieldUnitObjs`...\
@@ -214,9 +214,9 @@ WECB (0x18, 0x04, 256, Arg4)
 ...
 ```
 Now we are done!\
-I have already uploaded the modified [SSDT-Battery.aml](SSDT-Battery.aml) so you can use it right away. In it, I have also renamed `B1B2` (now called `R16B`) and newly defined `W16B` method to write to a 16-bit `FieldUnitObj` instead to easily recognize that the `FieldUnitObj` and the corresponding `Method` has been patched.
+I have already uploaded the modified [SSDT-Battery.aml](../../OpenCore/OC/ACPI/SSDT-Battery.aml) so you can use it right away. In it, I have also renamed `B1B2` (now called `R16B`) and newly defined `W16B` method to write to a 16-bit `FieldUnitObj` instead to easily recognize that the `FieldUnitObj` and the corresponding `Method` has been patched.
 ## Other things
 - What if the `OperationRegion` starts at `Offset` of `Zero`? Then `Arg0` should be `Zero`.
 - Be careful when converting `Base10` and `Hex`. Example: `256 = 0x100`.
-- If you have battery related `FieldUnitObjs` in `SystemMemory` `OperationRegions`, obviously you need to write new methods or at least modify the current ones. There is no need to do so for this ASUS laptop. But in case if you need it, see [SSDT-ECSMRW.dsl](Battery/SSDT-ECSMRW.dsl).
+- If you have battery related `FieldUnitObjs` in `SystemMemory` `OperationRegions`, obviously you need to write new methods or at least modify the current ones. There is no need to do so for this ASUS laptop. But in case if you need it, see [SSDT-ECSMRW.dsl](SSDT-ECSMRW.dsl).
 - Studying the ACPI specs and usages is more interesting than I thought. I might work on [Battery Information Supplement](https://github.com/acidanthera/VirtualSMC/blob/master/Docs/Battery%20Information%20Supplement.md) and [Hibernate on Low Battery](https://applelife.ru/threads/hibernate-pri-razrjade-batarei.2874421/). The latter one is the ultimate fix to this [issue](https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/issues/9).


### PR DESCRIPTION
This pull request fixes links in ACPI README that are broken as a result of the recent commits(https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/commit/1d355e23b7ebec4765377d4bda7fc0cc5481fbb3 and https://github.com/whatnameisit/Asus-Vivobook-X510UA-BQ490-Hackintosh/commit/0e0f9137df1d6f2cd146eedef50343a9416522ec) in the original guide. See https://github.com/LeeBinder/Asus-Vivobook-S510UA-Hackintosh/issues/1#issuecomment-787878023.