### PR TITLE
Update on UEFI-AppleInput

### DIFF
--- a/OpenCore/EFI/OC/config.plist
+++ b/OpenCore/EFI/OC/config.plist
@@ -1623,7 +1623,7 @@
 		<key>AppleInput</key>
 		<dict>
 			<key>AppleEvent</key>
-			<string>OEM</string>
+			<string>Auto</string>
 			<key>CustomDelays</key>
 			<string>Auto</string>
 			<key>KeyInitialDelay</key>


### PR DESCRIPTION
Before this, on boot from this plist, the bootloader crashes and hangs on the boot screen with error:
"OCTY: Failed to locate apple event protocol- Not Found.
Halting on critical Error"